### PR TITLE
Add shortcut to configure display

### DIFF
--- a/src/etc/xdg/xdg-Lubuntu/lxqt/globalkeyshortcuts.conf
+++ b/src/etc/xdg/xdg-Lubuntu/lxqt/globalkeyshortcuts.conf
@@ -215,3 +215,8 @@ Exec=pcmanfm-qt
 Comment=Show/hide runner
 Enabled=true
 path=/runner/show_hide_dialog
+
+[XF86Display.43]
+Comment=Launch Monitor
+Enabled=true
+Exec=lxqt-config-monitor


### PR DESCRIPTION
Launch the lxqt-config-monitor tool when the Display key (XF86Display) key is pressed.